### PR TITLE
[Merged by Bors] - Document container privileges

### DIFF
--- a/docs/modules/listener-operator/pages/security.adoc
+++ b/docs/modules/listener-operator/pages/security.adoc
@@ -1,0 +1,12 @@
+= Security
+
+== Container privileges
+
+The Listener Operator runs as a set of root containers. This is needed for two reasons:
+
+1. We need to run as root to have permission to create the Unix domain socket hosting the Container Storage interface (CSI)
+driver. The Kubelet communicates with the CSI driver over this socket.
+2. We need to run as root to have permission to write information about externally exposed addresses into the pods' volume paths, as directed
+by the CSI.
+
+Running as root is currently a hard requirement.

--- a/docs/modules/listener-operator/partials/nav.adoc
+++ b/docs/modules/listener-operator/partials/nav.adoc
@@ -5,3 +5,4 @@
 ** xref:listener-operator:listener.adoc[]
 ** xref:listener-operator:listenerclass.adoc[]
 ** xref:listener-operator:volume.adoc[]
+* xref:secret-operator:security.adoc[]


### PR DESCRIPTION
# Description

Adds documentation to explain why the listener operator needs to run as root in its containers. fixes #72

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
