### PR TITLE
Fix whitespace control in README generation

### DIFF
--- a/.readme/README.md.j2
+++ b/.readme/README.md.j2
@@ -4,11 +4,22 @@
 {%- set related_reading_links=[] -%}
 {%- set no_jenkins_job_badge=true -%}
 
-{% include "partials/borrowed/header.md.j2" %}
-{% include "partials/borrowed/links.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/header.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/main.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/links.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/footer.md.j2" %}
+{% filter trim %}
+  {%- include "partials/main.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/related_reading.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/footer.md.j2" -%}
+{% endfilter %}
+
+{% filter trim %}
+  {%- include "partials/borrowed/related_reading.md.j2" -%}
+{% endfilter %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["rust/operator-binary", "rust/csi-grpc"]
+resolver = "2"
 
 [workspace.package]
 version = "0.0.0-dev"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 <h1 align="center">Stackable Listener Operator</h1>
 
-
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/stackabletech/listener-operator/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://docs.stackable.tech/home/stable/contributor/index.html)
 [![License OSL3.0](https://img.shields.io/badge/license-OSL3.0-green)](./LICENSE)
@@ -33,7 +32,6 @@ If you are interested in the most recent state of this repository, check out the
 The documentation for all Stackable products can be found at [docs.stackable.tech](https://docs.stackable.tech).
 
 If you have a question about the Stackable Data Platform contact us via our [homepage](https://stackable.tech/) or ask a public questions in our [Discussions forum](https://github.com/orgs/stackabletech/discussions).
-
 
 ## About The Stackable Data Platform
 


### PR DESCRIPTION
# Description

So far we would include files with all their whitespace which can lead to markdownlint errors and inconsistencies. Now we trim everything we include.

This also switches to resolver v2 for the workspace because the render-readme step would warn about it.

Part of https://github.com/stackabletech/issues/issues/492