### PR TITLE
remove init container from daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- Init container deployed by the Helm chart as part of the daemonset ([#174]).
+
+[#174]: https://github.com/stackabletech/listener-operator/pull/174
+
 ## [24.3.0] - 2024-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- Init container deployed by the Helm chart as part of the daemonset ([#174]).
+- Init container deployed by the Helm chart as part of the daemonset. It was added a an automatic migration between SDP versions and is not needed anymore  ([#174]).
 
 [#174]: https://github.com/stackabletech/listener-operator/pull/174
 

--- a/deploy/helm/listener-operator/templates/node-daemonset.yaml
+++ b/deploy/helm/listener-operator/templates/node-daemonset.yaml
@@ -64,33 +64,6 @@ spec:
               mountPath: /registration
             - name: csi
               mountPath: /csi
-      initContainers:
-        # https://github.com/stackabletech/listener-operator/issues/76
-        # In https://github.com/stackabletech/listener-operator/pull/45 we introduced a breaking change by shortening the CSI registration path
-        # This resulted in the following error "node_register.go:43] file exists in socketPath /registration/listeners.stackable.tech-reg.sock but it's not a socket.: &{name:listeners.stackable.tech-reg.sock size:4096 mode:2147484141 modTime:{wall:984732078ext:63815759330 loc:0xf864a0} sys:{Dev:64769 Ino:43688551 Nlink:2 Mode:16877 Uid:0 Gid:0 X__pad0:0 Rdev:0 Size:4096 Blksize:4096 Blocks:8 Atim:{Sec:1680162505 Nsec:36073186} Mtim:{Sec:1680162530 Nsec:984732078} Ctim:{Sec:1680162530 Nsec:984732078} X__unused:[0 0 0]}}"
-        # This init container removes the "old" directory, so that a unix socket with the same path can be created instead
-        # TODO: Should be removed in a release after 23.4
-        - name: migrate-longer-csi-registration-path
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          resources:
-            {{ .Values.node.driver.resources | toYaml | nindent 12 }}
-          command:
-            - /bin/bash
-            - -euo
-            - pipefail
-            - -x
-            - -c
-            - |
-              ls -la /registration
-              echo "Removing old (long) CSI registration path"
-              if [ -d "/registration/listeners.stackable.tech-reg.sock" ]; then rmdir /registration/listeners.stackable.tech-reg.sock; fi
-              ls -la /registration
-          volumeMounts:
-            - name: registration-sock
-              mountPath: /registration
-          securityContext:
-            runAsUser: 0
       volumes:
         - name: registration-sock
           hostPath:


### PR DESCRIPTION
# Description

Remove init container deployed by the Helm chart and that was used for backwards compatibility with older versions of the SDP.

Tests pass.

```
--- PASS: kuttl (102.76s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke-nodeport (102.75s)
PASS

```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
