### PR TITLE
Adding verb patch to persistentvolumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Propagate `external_traffic_policy` from ListenerClass to created Services ([#196]).
+- Adding verb `patch` to persistentvolumes in roles.yaml to support update to csi-provisioner v5.x.x ([#203]).
 
 ### Changed
 
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#174]: https://github.com/stackabletech/listener-operator/pull/174
 [#194]: https://github.com/stackabletech/listener-operator/pull/194
 [#196]: https://github.com/stackabletech/listener-operator/pull/196
+[#203]: https://github.com/stackabletech/listener-operator/pull/203
 [#208]: https://github.com/stackabletech/listener-operator/pull/208
 
 ## [24.3.0] - 2024-03-20

--- a/deploy/helm/listener-operator/templates/roles.yaml
+++ b/deploy/helm/listener-operator/templates/roles.yaml
@@ -69,6 +69,7 @@ rules:
       - get
       - list
       - watch
+      - patch
       - create
       - delete
   - apiGroups:


### PR DESCRIPTION
# Description

According to https://github.com/kubernetes-csi/external-provisioner/pull/1155/files we need to adapt verbs for the `persitantvolumes` in our secret-operator RBAC rules.

The update itself will be done in https://github.com/stackabletech/secret-operator/pull/455 and https://github.com/stackabletech/listener-operator/pull/203

This PR is a change accordingly.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
