### PR TITLE
fix: Propagate serviceAnnotations to created Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Listener.status.addresses is now de-duplicated ([#231]).
 - Listener controller now listens for ListenerClass updates ([#231]).
+- Propagate `ListenerClass.spec.serviceAnnotations` to the created Services ([#XXX]).
 
 [#231]: https://github.com/stackabletech/listener-operator/pull/231
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ All notable changes to this project will be documented in this file.
 
 - Listener.status.addresses is now de-duplicated ([#231]).
 - Listener controller now listens for ListenerClass updates ([#231]).
-- Propagate `ListenerClass.spec.serviceAnnotations` to the created Services ([#XXX]).
+- Propagate `ListenerClass.spec.serviceAnnotations` to the created Services ([#234]).
 
 [#231]: https://github.com/stackabletech/listener-operator/pull/231
+[#234]: https://github.com/stackabletech/listener-operator/pull/234
 
 ## [24.7.0] - 2024-07-24
 

--- a/rust/operator-binary/src/listener_controller.rs
+++ b/rust/operator-binary/src/listener_controller.rs
@@ -237,6 +237,7 @@ pub async fn reconcile(listener: Arc<Listener>, ctx: Arc<Ctx>) -> Result<control
                 .context(BuildListenerOwnerRefSnafu)?]),
             // Propagate the labels from the Listener object to the Service object, so it can be found easier
             labels: listener.metadata.labels.clone(),
+            annotations: Some(listener_class.spec.service_annotations),
             ..Default::default()
         },
         spec: Some(ServiceSpec {


### PR DESCRIPTION
# Description

Reported in https://github.com/orgs/stackabletech/discussions/57

This PR actually now uses `ListenerClass.spec.serviceAnnotations`...

The following ListenerClass
```yaml
apiVersion: listeners.stackable.tech/v1alpha1
kind: ListenerClass
metadata:
  name: lb-with-annotations
spec:
  serviceType: LoadBalancer
  serviceAnnotations:
    # networking.gke.io/load-balancer-type: Internal
    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
    service.beta.kubernetes.io/aws-load-balancer-type: internal
```
now produces the correct annotations on the Service

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
