### PR TITLE
fix: Default external-unstable ListenerClass back to IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
   (previously NodePort and ClusterIP would prefer IP addresses).
   However, the `external-unstable` ListenerClass deployed by the listener-operator still uses the IPs to avoid a regression,
   e.g. in the case of `kind` clusters the host can probably not resolve the hostname of the Kubernetes node
-  (such as `kind-control-plane`) ([#233], [#XXX]).
+  (such as `kind-control-plane`) ([#233], [#243]).
 - `Listener.status.addresses` for NodePort listeners now includes replicas that are currently unavailable ([#231]).
 - Stale Listener subobjects will now be deleted ([#232]).
 - Tagged Listener Services with the SDP labels ([#232]).
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 [#234]: https://github.com/stackabletech/listener-operator/pull/234
 [#237]: https://github.com/stackabletech/listener-operator/pull/237
 [#238]: https://github.com/stackabletech/listener-operator/pull/238
+[#243]: https://github.com/stackabletech/listener-operator/pull/243
 
 ## [24.7.0] - 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,16 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- BREAKING: `Listener.status.addresses` now defaults to hostnames for ClusterIP services.
+  (NodePorts remain on the IP address of the Node for now, LoadBalancers already prefer the hostname).
+  Previously ClusterIP would prefer IP addresses ([#233], [#XXX]).
+
+- BREAKING: `Listener.status.addresses` now defaults to hostnames for all service types
+  (previously NodePort and ClusterIP would prefer IP addresses).
+  However, the `external-unstable` ListenerClass deployed by the listener-operator still uses the IPs to avoid a regression,
+  e.g. in the case of `kind` clusters the host can probably not resolve the hostname of the Kubernetes node
+  (such as `kind-control-plane`) ([#233], [#XXX]).
 - `Listener.status.addresses` for NodePort listeners now includes replicas that are currently unavailable ([#231]).
-- `Listener.status.addresses` now defaults to DNS hostnames for all service types (previously NodePort and ClusterIP would prefer IP addresses, [#233]).
 - Stale Listener subobjects will now be deleted ([#232]).
 - Tagged Listener Services with the SDP labels ([#232]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BREAKING: `Listener.status.addresses` now defaults to hostnames for ClusterIP services.
-  (NodePorts remain on the IP address of the Node for now, LoadBalancers already prefer the hostname).
-  Previously ClusterIP would prefer IP addresses ([#233], [#XXX]).
-
 - BREAKING: `Listener.status.addresses` now defaults to hostnames for all service types
   (previously NodePort and ClusterIP would prefer IP addresses).
   However, the `external-unstable` ListenerClass deployed by the listener-operator still uses the IPs to avoid a regression,

--- a/deploy/helm/listener-operator/templates/listener-classes.yaml
+++ b/deploy/helm/listener-operator/templates/listener-classes.yaml
@@ -14,6 +14,11 @@ metadata:
   name: external-unstable
 spec:
   serviceType: NodePort
+  # Ideally we would prefer the Hostname here, but up to (including) SDP 24.7 we defaulted to the IP.
+  # We actually defaulted to Hostname for some weeks, but noticed this breaks external access to kind clusters, as the
+  # local machines can not resolve the hostnames of the nodes (such as kind-control-plane).
+  # So we stick to the old default and re-visit the default later - after SDP 24.11 is released.
+  preferredAddressType: IP
 ---
 apiVersion: listeners.stackable.tech/v1alpha1
 kind: ListenerClass
@@ -36,6 +41,11 @@ metadata:
   name: external-unstable
 spec:
   serviceType: NodePort
+  # Ideally we would prefer the Hostname here, but up to (including) SDP 24.7 we defaulted to the IP.
+  # We actually defaulted to Hostname for some weeks, but noticed this breaks external access to kind clusters, as the
+  # local machines can not resolve the hostnames of the nodes (such as kind-control-plane).
+  # So we stick to the old default and re-visit the default later - after SDP 24.11 is released.
+  preferredAddressType: IP
 ---
 apiVersion: listeners.stackable.tech/v1alpha1
 kind: ListenerClass
@@ -51,6 +61,10 @@ spec:
   # or on-premise environments that don't support external LoadBalancer peering (such as Calico (https://docs.tigera.io/calico/latest/networking/configuring/advertise-service-ips)
   # or MetalLB (https://metallb.org/)).
   serviceType: NodePort
+  # As the nodes have stable addresses we expect them to have hostnames that are resolvable outside of Kubernetes.
+  # And yes, we know this causes problems when running on kind with the stable-nodes preset (default), as the kind node
+  # hostname is very likely not resolvable on the host machine.
+  preferredAddressType: Hostname
 {{ else }}
 {{ fail "An invalid preset was configured" }}
 {{ end }}


### PR DESCRIPTION
# Description

Reasoning is on the code comments and changelog.
Relevant discussion: https://stackable-workspace.slack.com/archives/C0312UB3LLE/p1730312706917569?thread_ts=1730298381.528779&cid=C0312UB3LLE

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
