### PR TITLE
fix(docker): Give RBAC permission to delete Services

### DIFF
--- a/deploy/helm/listener-operator/templates/roles.yaml
+++ b/deploy/helm/listener-operator/templates/roles.yaml
@@ -60,6 +60,7 @@ rules:
       - list
       - watch
       - create
+      - delete # Needed to set an ownerRef on already existing Services
       - patch
   - apiGroups:
       - ""


### PR DESCRIPTION
# Description

Should hopefully fix
`failed to apply Service.v1./listener-lab1-hdfs-namenode-default-0.stack-lab: failed to apply patch: unable to patch resource "listener-lab1-hdfs-namenode-default-0": ApiError: services "listener-lab1-hdfs-namenode-default-0" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>: Forbidden (ErrorResponse { status: "Failure", message: "services \"listener-lab1-hdfs-namenode-default-0\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>", reason: "Forbidden", code: 403 }): services "listener-lab1-hdfs-namenode-default-0" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>: Forbidden`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
