### PR TITLE
fix: Fix republishing volumes after a Node restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Give RBAC permission to `delete` Services, which is needed to set an ownerRef on already existing Services ([#283]).
+- Fix the error "failed to write content: File exists (os error 17)" after a
+  Node restart ([#284]).
 
 [#267]: https://github.com/stackabletech/listener-operator/pull/267
 [#268]: https://github.com/stackabletech/listener-operator/pull/268
 [#279]: https://github.com/stackabletech/listener-operator/pull/279
 [#282]: https://github.com/stackabletech/listener-operator/pull/282
 [#283]: https://github.com/stackabletech/listener-operator/pull/283
+[#284]: https://github.com/stackabletech/listener-operator/pull/284
 
 ## [24.11.1] - 2025-01-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,9 +2126,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6791,10 +6791,10 @@ rec {
       };
       "ring" = rec {
         crateName = "ring";
-        version = "0.17.11";
+        version = "0.17.13";
         edition = "2021";
-        links = "ring_core_0_17_11_";
-        sha256 = "0wzyhdbf71ndd14kkpyj2a6nvczvli2mndzv2al7r26k4yp4jlys";
+        links = "ring_core_0_17_13_";
+        sha256 = "1vjhhlmpqqd9lc53ffjj1yk203188n2km27g3myvssm15a1mvb3h";
         dependencies = [
           {
             name = "cfg-if";

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -592,19 +592,25 @@ mod pod_dir {
             default_addr_dir.get_or_insert(addr_dir);
         }
 
-        let default_addr_link = target_path.join("default-address");
-        // Remove any existing symlink because `tokio::fs::symlink` fails if it already exists.
-        // This happens if the node was restarted. The pod then restarts with the same UID and
-        // the pre-populated volume.
-        let _ = tokio::fs::remove_file(&default_addr_link).await;
-        tokio::fs::symlink(
-            default_addr_dir
-                .context(NoDefaultAddressSnafu)?
-                .strip_prefix(target_path)
-                .context(DefaultAddrIsOutsideRootSnafu)?,
-            &default_addr_link,
-        )
-        .await?;
+        let relative_default_addr_dir = default_addr_dir
+            .context(NoDefaultAddressSnafu)?
+            .strip_prefix(target_path)
+            .context(DefaultAddrIsOutsideRootSnafu)?
+            .to_owned();
+        let default_addr_dir_link = target_path.join("default-address");
+        // Check if the symlink needs to be updated
+        if tokio::fs::read_link(&default_addr_dir_link)
+            .await
+            .ok()
+            .as_ref()
+            != Some(&relative_default_addr_dir)
+        {
+            // Remove any existing symlink because `tokio::fs::symlink` fails if it already exists.
+            // This happens if the node was restarted. The pod then restarts with the same UID and
+            // the pre-populated volume.
+            let _ = tokio::fs::remove_file(&default_addr_dir_link).await;
+            tokio::fs::symlink(relative_default_addr_dir, &default_addr_dir_link).await?;
+        }
         Ok(())
     }
 }

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -591,12 +591,18 @@ mod pod_dir {
             }
             default_addr_dir.get_or_insert(addr_dir);
         }
+
+        let default_addr_link = target_path.join("default-address");
+        // Remove any existing symlink because `tokio::fs::symlink` fails if it already exists.
+        // This happens if the node was restarted. The pod then restarts with the same UID and
+        // the pre-populated volume.
+        let _ = tokio::fs::remove_file(&default_addr_link).await;
         tokio::fs::symlink(
             default_addr_dir
                 .context(NoDefaultAddressSnafu)?
                 .strip_prefix(target_path)
                 .context(DefaultAddrIsOutsideRootSnafu)?,
-            target_path.join("default-address"),
+            &default_addr_link,
         )
         .await?;
         Ok(())

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
             .await?;
             if csi_endpoint
                 .symlink_metadata()
-                .map_or(false, |meta| meta.file_type().is_socket())
+                .is_ok_and(|meta| meta.file_type().is_socket())
             {
                 let _ = std::fs::remove_file(&csi_endpoint);
             }


### PR DESCRIPTION
# Description

Fix the error "failed to write content: File exists (os error 17)" after a Node restart.

Fixes #262 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
