### PR TITLE
chore: Use correct helm value name in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Split helm values for independent configuration ([#334]).
   - `controller` values have been moved to `csiProvisioner.controllerService`.
   - `csiProvisioner` values have been moved to `csiProvisioner.externalProvisioner`
-  - `csiNodeDriverRegistrar` values have been moved to `csiNodeDriver.nodeRegistrar`.
+  - `csiNodeDriverRegistrar` values have been moved to `csiNodeDriver.nodeDriverRegistrar`.
   - `node.driver` values have been moved to `csiNodeDriver.nodeService`.
   - `podAnnotations` has been split into `csiProvisioner.podAnnotations` and `csiNodeDriver.podAnnotations`.
   - `podSecurityContext` has been split into `csiProvisioner.podSecurityContext` and `csiNodeDriver.podSecurityContext`.

--- a/deploy/helm/listener-operator/values.yaml
+++ b/deploy/helm/listener-operator/values.yaml
@@ -72,9 +72,7 @@ csiNodeDriver:
 
   affinity: {}
 
-  # priority: ...
   # priorityClassName: ...
-  # preemptionPolicy: ...
 
   nodeService:
     resources:


### PR DESCRIPTION
Small corrections from https://github.com/stackabletech/listener-operator/pull/334