### PR TITLE
feat!: Make NodePort stickiness configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "darling",
  "regex",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.99.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "chrono",
  "clap",
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2661,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "chrono",
  "k8s-openapi",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "axum",
  "clap",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.8.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "schemars",
  "serde",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.8.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.99.0#be422046081be2fb9f37dfece660e007273f4e32"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Flistenerclass-stickiness#16a07e19197f1ba2bb129dae8de724cc149caae0"
 dependencies = [
  "convert_case",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ walkdir = "2.5.0"
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "feat/listenerclass-stickiness" }

--- a/deploy/helm/listener-operator/crds/crds.yaml
+++ b/deploy/helm/listener-operator/crds/crds.yaml
@@ -82,6 +82,21 @@ spec:
                     - LoadBalancer
                     - ClusterIP
                   type: string
+                stickyNodePorts:
+                  default: false
+                  description: |-
+                    Wether a Pod exposed using a NodePort should be pinned to a specific Kubernetes node.
+
+                    By pinning the Pod to a specific (stable) Kubernetes node, stable addresses can be
+                    provided using NodePorts. The stickiness is achieved by listener-operator by setting the
+                    `volume.kubernetes.io/selected-node` annotation on the Listener PVC.
+
+                    However, this only works on setups with long-living nodes. If your nodes are rotated on
+                    a regular basis, the Pods previously running on a removed node will be stuck in Pending
+                    until you delete the PVC with the stickiness.
+
+                    Because of this we don't enable stickiness by default to support all environments.
+                  type: boolean
               required:
                 - serviceType
               type: object


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/770
Needs https://github.com/stackabletech/operator-rs/pull/1105

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
