### PR TITLE
fix(rbac): Restore listeners/finalizers update permission

### DIFF
--- a/deploy/helm/listener-operator/templates/roles.yaml
+++ b/deploy/helm/listener-operator/templates/roles.yaml
@@ -176,7 +176,8 @@ rules:
     verbs:
       - patch
   # Required by Kubernetes to allow setting blockOwnerDeletion on resources (e.g. Services)
-  # owned by a Listener.
+  # owned by a Listener. This is needed when the OwnerReferencesPermissionEnforcement admission
+  # controller is enabled (which is by default in OpenShift)
   - apiGroups:
       - listeners.stackable.tech
     resources:

--- a/deploy/helm/listener-operator/templates/roles.yaml
+++ b/deploy/helm/listener-operator/templates/roles.yaml
@@ -175,6 +175,14 @@ rules:
       - listeners/status
     verbs:
       - patch
+  # Required by Kubernetes to allow setting blockOwnerDeletion on resources (e.g. Services)
+  # owned by a Listener.
+  - apiGroups:
+      - listeners.stackable.tech
+    resources:
+      - listeners/finalizers
+    verbs:
+      - update
   # PodListeners record the resolved listener addresses for each volume mounted in a Pod.
   # Created by the CSI node driver when a Pod first mounts a Listener volume, then patched
   # to add entries for additional volumes.


### PR DESCRIPTION
Fixes a rule accidentally removed in #380

Without the `listeners/finalizers` `update`  rule, the listener operator is unable to set `metadata.ownerReferences[].blockOwnerDeletion` on the Service (or other) resource.

This appears to have only affected OpenShift clusters in our testing because OpenShift enables the [OwnerReferencesPermissionEnforcement] admission plugin by default.

[OwnerReferencesPermissionEnforcement]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement