### PR TITLE
chore: Bump Rust edition to 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1544,7 +1544,7 @@ rec {
       "csi-grpc" = rec {
         crateName = "csi-grpc";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./rust/csi-grpc; };
         libName = "csi_grpc";
         authors = [
@@ -8763,9 +8763,9 @@ rec {
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
-        version = "0.103.9";
+        version = "0.103.13";
         edition = "2021";
-        sha256 = "0lwg1nnyv7pp2lfwwjhy81bxm233am99jnsp3iymdhd6k8827pyp";
+        sha256 = "0vkm7z9pnxz5qz66p2kmyy2pwx0g4jnsbqk5xzfhs4czcjl2ki31";
         libName = "webpki";
         dependencies = [
           {
@@ -9985,7 +9985,7 @@ rec {
       "stackable-listener-operator" = rec {
         crateName = "stackable-listener-operator";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         crateBin = [
           {
             name = "stackable-listener-operator";
@@ -10096,7 +10096,7 @@ rec {
       "stackable-listener-operator-olm-deployer" = rec {
         crateName = "stackable-listener-operator-olm-deployer";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         crateBin = [
           {
             name = "stackable-listener-operator-olm-deployer";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.0.0-dev"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/stackabletech/listener-operator"
 
 [workspace.dependencies]

--- a/rust/olm-deployer/src/env/mod.rs
+++ b/rust/olm-deployer/src/env/mod.rs
@@ -19,33 +19,33 @@ pub(super) fn maybe_copy_env(
     target_gvk: &GroupVersionKind,
 ) -> anyhow::Result<()> {
     let target_kind_set = ["DaemonSet", "Deployment"];
-    if target_kind_set.contains(&target_gvk.kind.as_str()) {
-        if let Some(env) = deployer_env_var(source) {
-            for container in containers(target)? {
-                match container {
-                    serde_json::Value::Object(c) => {
-                        let json_env = env
-                            .iter()
-                            .map(|e| serde_json::json!(e))
-                            .collect::<Vec<serde_json::Value>>();
+    if target_kind_set.contains(&target_gvk.kind.as_str())
+        && let Some(env) = deployer_env_var(source)
+    {
+        for container in containers(target)? {
+            match container {
+                serde_json::Value::Object(c) => {
+                    let json_env = env
+                        .iter()
+                        .map(|e| serde_json::json!(e))
+                        .collect::<Vec<serde_json::Value>>();
 
-                        match c.get_mut("env") {
-                            Some(env) => match env {
-                                v @ serde_json::Value::Null => {
-                                    *v = serde_json::json!(json_env);
-                                }
-                                serde_json::Value::Array(container_env) => {
-                                    container_env.extend_from_slice(&json_env)
-                                }
-                                _ => anyhow::bail!("env is not null or an array"),
-                            },
-                            None => {
-                                c.insert("env".to_string(), serde_json::json!(json_env));
+                    match c.get_mut("env") {
+                        Some(env) => match env {
+                            v @ serde_json::Value::Null => {
+                                *v = serde_json::json!(json_env);
                             }
+                            serde_json::Value::Array(container_env) => {
+                                container_env.extend_from_slice(&json_env)
+                            }
+                            _ => anyhow::bail!("env is not null or an array"),
+                        },
+                        None => {
+                            c.insert("env".to_string(), serde_json::json!(json_env));
                         }
                     }
-                    _ => anyhow::bail!("no containers found in object {}", target.name_any()),
                 }
+                _ => anyhow::bail!("no containers found in object {}", target.name_any()),
             }
         }
     }

--- a/rust/olm-deployer/src/main.rs
+++ b/rust/olm-deployer/src/main.rs
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
                             env::maybe_copy_env(&deployment, &mut obj, &gvk)?;
                             resources::maybe_copy_resources(&deployment, &mut obj, &gvk)?;
                             // ---------- apply
-                            apply(&api, obj, &gvk.kind).await?
+                            apply(&api, obj, &gvk.kind).await?;
                         }
                     }
                 }

--- a/rust/olm-deployer/src/resources/mod.rs
+++ b/rust/olm-deployer/src/resources/mod.rs
@@ -19,15 +19,15 @@ pub(super) fn maybe_copy_resources(
     target_gvk: &GroupVersionKind,
 ) -> anyhow::Result<()> {
     let target_kind_set = ["DaemonSet", "Deployment"];
-    if target_kind_set.contains(&target_gvk.kind.as_str()) {
-        if let Some(res) = deployment_resources(source) {
-            for container in containers(target)? {
-                match container {
-                    serde_json::Value::Object(c) => {
-                        c.insert("resources".to_string(), serde_json::json!(res));
-                    }
-                    _ => anyhow::bail!("no containers found in object {}", target.name_any()),
+    if target_kind_set.contains(&target_gvk.kind.as_str())
+        && let Some(res) = deployment_resources(source)
+    {
+        for container in containers(target)? {
+            match container {
+                serde_json::Value::Object(c) => {
+                    c.insert("resources".to_string(), serde_json::json!(res));
                 }
+                _ => anyhow::bail!("no containers found in object {}", target.name_any()),
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes for Rust 2024 Compatibility 
Updates rustls-webpki to address reported security vulnerabilities.

Part of https://github.com/stackabletech/issues/issues/832

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
