### PR TITLE
fix: Re-add rbac permissions required by SDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Document Helm deployed RBAC permissions and remove unnecessary permissions ([#380]).
+- Document Helm deployed RBAC permissions and remove unnecessary permissions ([#380], [#397]).
 
 ### Fixed
 
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 [#380]: https://github.com/stackabletech/listener-operator/pull/380
 [#393]: https://github.com/stackabletech/listener-operator/pull/393
+[#397]: https://github.com/stackabletech/listener-operator/pull/397
 
 ## [26.3.0] - 2026-03-16
 

--- a/deploy/helm/listener-operator/templates/roles.yaml
+++ b/deploy/helm/listener-operator/templates/roles.yaml
@@ -61,7 +61,6 @@ rules:
       - get
       - list
       - watch
-      # Write permissions required by e.g. SDP on Openshift
       - create
       - update
       - patch

--- a/deploy/helm/listener-operator/templates/roles.yaml
+++ b/deploy/helm/listener-operator/templates/roles.yaml
@@ -61,6 +61,10 @@ rules:
       - get
       - list
       - watch
+      # Write permissions required by e.g. SDP on Openshift
+      - create
+      - update
+      - patch
   # Service created per Listener. Applied via SSA and tracked for orphan cleanup.
   - apiGroups:
       - ""


### PR DESCRIPTION
## Description

Restore permissions required for openshift, but desired on vanilla Kubernetes.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
