### PR TITLE
docs: clarify kubelet state dir on Tanzu deployments

### DIFF
--- a/docs/modules/listener-operator/pages/installation.adoc
+++ b/docs/modules/listener-operator/pages/installation.adoc
@@ -93,5 +93,7 @@ In case you are encountering the mentioned error (or listener-operator does not 
 
 === VMware Tanzu
 
-VMware Tanzu uses a non-standard Kubelet state directory. Installing listener-operator on Tanzu requires the argument
-`--set kubeletDir=/var/vcap/data/kubelet` to be added to the `helm install` command.
+Whether Tanzu uses a non-standard Kubelet state directory depends on the variant.
+BOSH-deployed clusters (Tanzu Kubernetes Grid Integrated Edition, formerly PKS) place it under `/var/vcap`, so installing listener-operator there requires the argument `--set kubeletDir=/var/vcap/data/kubelet` to be added to the `helm install` command.
+Standard clusters (Tanzu Kubernetes Grid and vSphere with Tanzu) use the default `/var/lib/kubelet` and need no override.
+If unsure, check the actual directory on a node before overriding.


### PR DESCRIPTION
## Description

Clarifies under which conditions VMware Tanzu deployments require a custom `kubeletDir`
