### PR TITLE
test: Verify "Finished Build and Publish" gate catches failures (DO NOT MERGE)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,14 +214,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # TEMPORARY - DO NOT MERGE
-      # Force this job to fail to reproduce the mergeable-broken-build bug and
-      # verify the fixed `finished` gate now reports failure instead of skipped.
-      - name: TEMP force failure to exercise the finished gate
-        run: |
-          echo "Intentionally failing publish-index-manifest."
-          exit 1
-
       - name: Publish and Sign Image Index to oci.stackable.tech
         id: publish-oci
         uses: stackabletech/actions/publish-image-index-manifest@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,6 +214,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # TEMPORARY - DO NOT MERGE
+      # Force this job to fail to reproduce the mergeable-broken-build bug and
+      # verify the fixed `finished` gate now reports failure instead of skipped.
+      - name: TEMP force failure to exercise the finished gate
+        run: |
+          echo "Intentionally failing publish-index-manifest."
+          exit 1
+
       - name: Publish and Sign Image Index to oci.stackable.tech
         id: publish-oci
         uses: stackabletech/actions/publish-image-index-manifest@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
@@ -372,13 +380,41 @@ jobs:
     # WARNING: Do not change the name unless you will also be changing the
     # Required Checks (in branch protections) in GitHub settings.
     name: Finished Build and Publish
+    # Run even when a dependency failed, was skipped or cancelled, so that this
+    # gate reflects the real outcome. Without `always()` a failed dependency
+    # would *skip* this job, and GitHub treats a skipped required check as
+    # passing - making a broken build mergeable.
+    if: always()
+    # List every leaf job directly. A transitive failure (e.g. a failed
+    # publish-index-manifest that skips openshift-preflight-check) does not
+    # surface as `failure` in `needs.*.result` unless the failing job is a
+    # direct dependency.
     needs:
+      - detect-changes
       - cargo-udeps
-      - openshift-preflight-check
+      - build-container-image
+      - publish-index-manifest
+      - provenance-oci
+      - provenance-quay
       - publish-helm-chart
+      - openshift-preflight-check
     runs-on: ubuntu-latest
     steps:
-      - run: echo "We are done here"
+      # Skipped dependencies are fine (jobs skip legitimately on merge_group
+      # events, forks, or when detect-changes finds no relevant changes). Only
+      # a failure or cancellation must fail this gate.
+      - name: Fail on any failed or cancelled dependency
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Dependency results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::A required job did not succeed (result: $result)"
+              exit 1
+            fi
+          done
+          echo "We are done here"
 
   notify:
     name: Failure Notification


### PR DESCRIPTION
**DO NOT MERGE.** Test branch for stackabletech/operator-templating#614.

## Purpose

Verify the fixed `Finished Build and Publish` gate on a real operator repo before rolling the template change out everywhere (per @NickLarsenNZ's request on operator-templating#614).

## What this branch does

1. Applies the fixed `finished` gate to `.github/workflows/build.yaml`:
   - `if: always()` so the gate always runs and reports a real success/failure conclusion.
   - Lists every leaf job directly in `needs`.
   - Fails on any `failure`/`cancelled` result, tolerating legitimate `skipped`.
2. **Temporarily** forces `publish-index-manifest` to fail (a throwaway `exit 1` step), reproducing the exact bug from listener-operator run [29825092091](https://github.com/stackabletech/listener-operator/actions/runs/29825092091).

## Expected result (proves the fix)

- `Publish/Sign … Index` → **failure**
- `Run OpenShift Preflight Check` → **skipped** (cascade)
- `Finished Build and Publish` → **failure** ✅ (previously this was *skipped*, which branch protection treated as passing → broken build was mergeable)

The PR should show as **not mergeable / checks failing**. That's success for this test.

After confirming, drop the forced-failure commit to check the gate goes green on a clean run, then close this PR without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)