### PR TITLE
fix: Honour image.pullSecrets in the CSI provisioner Deployment

### DIFF
--- a/deploy/helm/listener-operator/templates/csi-provisioner-deployment.yaml
+++ b/deploy/helm/listener-operator/templates/csi-provisioner-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- end }}
         {{- include "operator.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
## Description

The CSI provisioner Deployment read `.Values.imagePullSecrets`, while the node driver DaemonSet and `values.yaml` both use `.Values.image.pullSecrets`.

Looks like this was forgotten back in 2024 in https://github.com/stackabletech/listener-operator/pull/142.

I'd consider this a bug fix as the provisioner never received pull secrets this way.

Found while surveying the charts for values that templates read but `values.yaml` does not define.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
