### PR TITLE
fix: Make serviceAccount.name and serviceAccount.create work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ All notable changes to this project will be documented in this file.
 - Bump stackable-operator to 0.114.0 ([#411]).
 - Bump stackable-operator to 0.115.0 ([#416]).
 
+### Fixed
+
+- BREAKING: Honour `serviceAccount.name`, which the ServiceAccount and both CSI workloads
+  previously ignored in favour of a hardcoded name. `serviceAccount.create=false` now requires
+  `serviceAccount.name`; it used to fall back to the namespace default ServiceAccount, which lacks
+  the operator ClusterRole ([#418]).
+
 [#411]: https://github.com/stackabletech/listener-operator/pull/411
 [#416]: https://github.com/stackabletech/listener-operator/pull/416
+[#418]: https://github.com/stackabletech/listener-operator/pull/418
 
 ## [26.7.0] - 2026-07-21
 

--- a/deploy/helm/listener-operator/templates/_helpers.tpl
+++ b/deploy/helm/listener-operator/templates/_helpers.tpl
@@ -65,9 +65,9 @@ Create the name of the service account to use
 */}}
 {{- define "operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "operator.fullname" .) .Values.serviceAccount.name }}
+{{- default (printf "%s-serviceaccount" (include "operator.fullname" .)) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- required "serviceAccount.name is required when serviceAccount.create is false, because the chart then does not create a ServiceAccount for the operator to run as." .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/listener-operator/templates/csi-node-driver-daemonset.yaml
+++ b/deploy/helm/listener-operator/templates/csi-node-driver-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "operator.fullname" . }}-serviceaccount
+      serviceAccountName: {{ include "operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.csiNodeDriver.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/helm/listener-operator/templates/csi-provisioner-deployment.yaml
+++ b/deploy/helm/listener-operator/templates/csi-provisioner-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "operator.fullname" . }}-serviceaccount
+      serviceAccountName: {{ include "operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.csiProvisioner.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/helm/listener-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/listener-operator/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "operator.fullname" . }}-serviceaccount
+  name: {{ include "operator.serviceAccountName" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -20,7 +20,7 @@ metadata:
     {{- include "operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "operator.fullname" . }}-serviceaccount
+    name: {{ include "operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Same fix as stackabletech/hive-operator#742 please read there for details.

Fixing this here before I move the rest to operator templating because when we fix the `_helpers.tpl` and `serviceaccount.yaml` in templating they will be merged here and suddenly potentially make the whole create and name stuff actually work but those non-templated two files will still refer to the old SA which now doesn't exist and the pod won't start.

In other words: Currently it's ignored (broken). If we don't fix it here _first_ pods might not start. So we fix it here first, then do templating.

`secret-operator` has the same two workloads and needs the same fix.